### PR TITLE
Updating commonInitialisms from golang/lint (adding ACL + XMPP)

### DIFF
--- a/snaker.go
+++ b/snaker.go
@@ -80,8 +80,9 @@ func startsWithInitialism(s string) string {
 }
 
 // commonInitialisms, taken from
-// https://github.com/golang/lint/blob/32a87160691b3c96046c0c678fe57c5bef761456/lint.go#L702
+// https://github.com/golang/lint/blob/206c0f020eba0f7fbcfbc467a5eb808037df2ed6/lint.go#L731
 var commonInitialisms = map[string]bool{
+	"ACL":   true,
 	"API":   true,
 	"ASCII": true,
 	"CPU":   true,
@@ -116,6 +117,7 @@ var commonInitialisms = map[string]bool{
 	"UTF8":  true,
 	"VM":    true,
 	"XML":   true,
+	"XMPP":  true,
 	"XSRF":  true,
 	"XSS":   true,
 }


### PR DESCRIPTION
Simple update to keep commonInitialisms in sync.