### PR TITLE
Add "ETA" word to the common initialisms list

### DIFF
--- a/snaker.go
+++ b/snaker.go
@@ -102,6 +102,7 @@ var commonInitialisms = map[string]bool{
 	"CSS":   true,
 	"DNS":   true,
 	"EOF":   true,
+	"ETA":   true,
 	"GPU":   true,
 	"GUID":  true,
 	"HTML":  true,


### PR DESCRIPTION
This patch adds "ETA" word to the common initialisms list in order to
prevent conversion "ETA" to "e_t_a" from camel case to snake case.