### PR TITLE
Add method to configure snake to camel exceptions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 
 go:
-  - 1.2
-  - 1.3
+  - 1.8
+  - 1.9
   - tip
 
 install: go get -t -d -v ./... && go build -v ./...

--- a/snaker.go
+++ b/snaker.go
@@ -51,6 +51,11 @@ func snakeToCamel(s string, upperCase bool) string {
 	words := strings.Split(s, "_")
 
 	for i, word := range words {
+		if exception := snakeToCamelExceptions[word]; len(exception) > 0 {
+			result += exception
+			continue
+		}
+
 		if upperCase || i > 0 {
 			if upper := strings.ToUpper(word); commonInitialisms[upper] {
 				result += upper
@@ -136,4 +141,10 @@ var commonInitialisms = map[string]bool{
 	"XMPP":  true,
 	"XSRF":  true,
 	"XSS":   true,
+	"OAuth": true,
+}
+
+// add exceptions here for things that are not automatically convertable
+var snakeToCamelExceptions = map[string]string{
+	"oauth": "OAuth",
 }

--- a/snaker_test.go
+++ b/snaker_test.go
@@ -51,6 +51,10 @@ var _ = Describe("Snaker", func() {
 		It("sould work with concat initialisms", func() {
 			Expect(CamelToSnake("HTTPSID")).To(Equal("https_id"))
 		})
+
+		It("sould work with initialism where only certain characters are uppercase", func() {
+			Expect(CamelToSnake("OAuthClient")).To(Equal("oauth_client"))
+		})
 	})
 
 	Describe("SnakeToCamel test", func() {
@@ -77,6 +81,10 @@ var _ = Describe("Snaker", func() {
 
 		It("should simply work with id", func() {
 			Expect(SnakeToCamel("id")).To(Equal("ID"))
+		})
+
+		It("sould work with initialism where only certain characters are uppercase", func() {
+			Expect(SnakeToCamel("oauth_client")).To(Equal("OAuthClient"))
 		})
 	})
 


### PR DESCRIPTION
This makes oauth_client => OAuthClient work

If there are other exceptions where not every character is uppercase we can configure them like this. This fixes #10 