### PR TITLE
Added power support for the travis.yml file with ppc64le.  excluded the  go version 1.8  for amd64, ppc64le

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ go:
 # Disable version go:1.8
 jobs:
   exclude:
+    - arch: amd64
+      go: 1.8
     - arch: ppc64le
       go: 1.8
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: go
-
+arch:
+  - amd64
+  - ppc64le
 go:
   - 1.8
   - 1.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,6 @@ go:
 jobs:
   exclude:
     - arch: ppc64le
-      go:1.8
+      go: 1.8
 
 install: go get -t -d -v ./... && go build -v ./...

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,10 @@ go:
   - 1.8
   - 1.9
   - tip
+# Disable version go:1.8
+jobs:
+  exclude:
+    - arch: ppc64le
+      go:1.8
 
 install: go get -t -d -v ./... && go build -v ./...


### PR DESCRIPTION
Added power support for the travis.yml file with ppc64le. This is part of the Ubuntu distribution for ppc64le. 
This helps us simplify testing later when distributions are re-building and re-releasing.

excluded the go version 1.8 for amd64,ppc64le